### PR TITLE
Add a task to only sync prescription drugs.

### DIFF
--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -34,4 +34,25 @@ namespace :sync do
     sync_service.sync('appointments', patients, SyncAppointmentPayload, report_errors_on_class: Visit)
     sync_service.sync('prescription_drugs', patients, SyncPrescriptionDrugPayload)
   end
+
+  desc 'Sync prescription drug data with simple server'
+  task :sync_prescription_drugs, [:simple_uuid] => :environment do |_t, args|
+    host = ENV.fetch('SIMPLE_SERVER_HOST')
+    user_id = ENV.fetch('SIMPLE_SERVER_USER_ID')
+    access_token = ENV.fetch('SIMPLE_SERVER_ACCESS_TOKEN')
+    simple_uuid = args[:simple_uuid]
+
+    unless simple_uuid.present?
+      puts "simple_uuid not set; exiting."
+      next
+    end
+
+    since = Time.new(0)
+    facilities = simple_uuid.present? ? Facility.where(simple_uuid: simple_uuid) : Facility.all
+
+    patients = Patient.where(facility: facilities).where('updated_at >= ?', since)
+
+    sync_service = SyncService.new(host, user_id, access_token)
+    sync_service.sync('prescription_drugs', patients, SyncPrescriptionDrugPayload)
+  end
 end


### PR DESCRIPTION
This is need to avoid updating other models for facilities which have been already synced. This is temporary and should be reverted once syncing is done.