### PR TITLE
Use visit date for updated_at timestamps

### DIFF
--- a/app/payloads/sync_appointment_payload.rb
+++ b/app/payloads/sync_appointment_payload.rb
@@ -24,6 +24,6 @@ class SyncAppointmentPayload
       scheduled_date: visit.next_visit_on,
       status: 'visited',
       created_at: visit.measured_on_without_timestamp,
-      updated_at: Time.now }
+      updated_at: visit.measured_on_without_timestamp,}
   end
 end

--- a/app/payloads/sync_medical_history_payload.rb
+++ b/app/payloads/sync_medical_history_payload.rb
@@ -24,6 +24,6 @@ class SyncMedicalHistoryPayload
       diagnosed_with_hypertension: BOOLEAN_TO_ENUM_MAP[patient.diagnosed_with_hypertension],
       diabetes: 'unknown', # This information is not present in the red cards
       created_at: patient.registered_on_without_timestamp,
-      updated_at: Time.now }
+      updated_at: patient.registered_on_without_timestamp,}
   end
 end

--- a/app/payloads/sync_patient_payload.rb
+++ b/app/payloads/sync_patient_payload.rb
@@ -18,7 +18,7 @@ class SyncPatientPayload
       age: patient.age,
       age_updated_at: now,
       created_at: patient.registered_on_without_timestamp,
-      updated_at: now,
+      updated_at: patient.registered_on_without_timestamp,
       address: simple_address,
       phone_numbers: simple_phone_numbers
     }
@@ -50,7 +50,7 @@ class SyncPatientPayload
       country: 'India',
       pin: patient.pincode,
       created_at: patient.registered_on_without_timestamp,
-      updated_at: now }
+      updated_at: patient.registered_on_without_timestamp }
   end
 
   def simple_phone_numbers

--- a/app/payloads/sync_prescription_drug_payload.rb
+++ b/app/payloads/sync_prescription_drug_payload.rb
@@ -47,7 +47,7 @@ class SyncPrescriptionDrugPayload
         facility_id: visit.facility.simple_uuid,
         is_protocol_drug: PROTOCOL_DRUG_KEYS.include?(drug_name),
         created_at: visit.measured_on_without_timestamp,
-        updated_at: now }
+        updated_at: visit.measured_on_without_timestamp }
     else
       nil
     end


### PR DESCRIPTION
When syncing from card reader, we are marking the device_updated_at timestamp on simple server to the day that the record was synced. The reason for doing this was that the records are created when the nurse recorded them, and were updated in the system when we synced them to server. This is incorrect and inconsistent with the app behavior. 