### PR TITLE
Allow editing patients with sync errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ spec/examples.txt
 
 # CSV files
 *.csv
+
+.env
+.env.production

--- a/app/controllers/concerns/simple_server_syncable.rb
+++ b/app/controllers/concerns/simple_server_syncable.rb
@@ -1,17 +1,17 @@
 module SimpleServerSyncable
   extend ActiveSupport::Concern
-  included do
-    SIMPLE_SERVER_HOST ||= ENV.fetch('SIMPLE_SERVER_HOST')
-    SIMPLE_SERVER_USER_ID ||= ENV.fetch('SIMPLE_SERVER_USER_ID')
-    SIMPLE_SERVER_ACCESS_TOKEN ||= ENV.fetch('SIMPLE_SERVER_ACCESS_TOKEN')
 
+  SIMPLE_SERVER_HOST = ENV.fetch('SIMPLE_SERVER_HOST')
+  SIMPLE_SERVER_USER_ID = ENV.fetch('SIMPLE_SERVER_USER_ID')
+  SIMPLE_SERVER_ACCESS_TOKEN = ENV.fetch('SIMPLE_SERVER_ACCESS_TOKEN')
+
+  included do
     def sync_patients_for_facility(patients, facility)
-      sync_service = SyncService.new(
-        SIMPLE_SERVER_HOST,
-        SIMPLE_SERVER_USER_ID,
-        SIMPLE_SERVER_ACCESS_TOKEN,
-        facility.simple_uuid
-      )
+      sync_service = SyncService.new(SIMPLE_SERVER_HOST,
+                                     SIMPLE_SERVER_USER_ID,
+                                     SIMPLE_SERVER_ACCESS_TOKEN,
+                                     facility.simple_uuid)
+
       sync_service.sync_all(patients)
     end
   end

--- a/app/controllers/concerns/simple_server_syncable.rb
+++ b/app/controllers/concerns/simple_server_syncable.rb
@@ -1,9 +1,9 @@
 module SimpleServerSyncable
   extend ActiveSupport::Concern
   included do
-    SIMPLE_SERVER_HOST = ENV.fetch('SIMPLE_SERVER_HOST')
-    SIMPLE_SERVER_USER_ID = ENV.fetch('SIMPLE_SERVER_USER_ID')
-    SIMPLE_SERVER_ACCESS_TOKEN = ENV.fetch('SIMPLE_SERVER_ACCESS_TOKEN')
+    SIMPLE_SERVER_HOST ||= ENV.fetch('SIMPLE_SERVER_HOST')
+    SIMPLE_SERVER_USER_ID ||= ENV.fetch('SIMPLE_SERVER_USER_ID')
+    SIMPLE_SERVER_ACCESS_TOKEN ||= ENV.fetch('SIMPLE_SERVER_ACCESS_TOKEN')
 
     def sync_patients_for_facility(patients, facility)
       sync_service = SyncService.new(

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -62,9 +62,11 @@ class FacilitiesController < ApplicationController
   def sync
     @facility = Facility.find(params[:facility_id])
     authorize @facility
+
     begin
-      patients = Patient.where(facility: @facility).select(&:unsynced?)
+      patients = Patient.where(facility: @facility).select(&:syncable?)
       sync_patients_for_facility(patients, @facility)
+
       redirect_back(fallback_location: root_path, notice: 'Patients for facility synced successfully')
     rescue SyncError => error
       redirect_back(fallback_location: root_path, notice: error.message)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -38,7 +38,7 @@ class PatientsController < ApplicationController
 
   def update
     respond_to do |format|
-      if @patient.update(patient_with_parsed_medical_history)
+      if @patient.update(patient_with_parsed_medical_history.merge(author: current_user))
         format.html { redirect_to [@district, @facility, @patient], notice: 'Patient was successfully updated.' }
         format.json { render :show, status: :ok, location: @patient }
       else
@@ -59,7 +59,9 @@ class PatientsController < ApplicationController
   def sync
     @patient = Patient.find(params[:patient_id])
     authorize @patient
-    return redirect_back(fallback_location: root_path, alert: 'Can only sync unsynced patients!') unless @patient.unsynced?
+
+    return redirect_back(fallback_location: root_path, alert: 'Can only sync unsynced patients!') unless @patient.syncable?
+
     begin
       sync_patients_for_facility([@patient], @facility)
       redirect_back(fallback_location: root_path, notice: 'Patient synced successfully')

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -38,7 +38,7 @@ class PatientsController < ApplicationController
 
   def update
     respond_to do |format|
-      if @patient.update(patient_with_parsed_medical_history.merge(author: current_user))
+      if @patient.update(patient_with_parsed_medical_history)
         format.html { redirect_to [@district, @facility, @patient], notice: 'Patient was successfully updated.' }
         format.json { render :show, status: :ok, location: @patient }
       else

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -71,53 +71,54 @@ class PatientsController < ApplicationController
   end
 
   private
-    def set_district
-      @district = District.find(params[:district_id])
-      authorize @district, :show?
-    end
 
-    def set_facility
-      @facility = Facility.find(params[:facility_id])
-      authorize @facility, :show?
-    end
+  def set_district
+    @district = District.find(params[:district_id])
+    authorize @district, :show?
+  end
 
-    def set_patient
-      @patient = Patient.find(params[:id])
-      authorize @patient
-    end
+  def set_facility
+    @facility = Facility.find(params[:facility_id])
+    authorize @facility, :show?
+  end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def patient_params
-      params.require(:patient).permit(
-        :treatment_number,
-        :registered_on,
-        :name,
-        :gender,
-        :age,
-        :house_number,
-        :street_name,
-        :area,
-        :village,
-        :district,
-        :pincode,
-        :phone,
-        :alternate_phone,
-        :already_on_treatment,
-        :prior_heart_attack,
-        :heart_attack_in_last_3_years,
-        :prior_stroke,
-        :chronic_kidney_disease,
-        :diagnosed_with_hypertension,
-        :medication1_name,
-        :medication1_dose,
-        :medication2_name,
-        :medication2_dose,
-        :medication3_name,
-        :medication3_dose,
-        :medication4_name,
-        :medication4_dose
-      )
-    end
+  def set_patient
+    @patient = Patient.find(params[:id])
+    authorize @patient
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def patient_params
+    params.require(:patient).permit(
+      :treatment_number,
+      :registered_on,
+      :name,
+      :gender,
+      :age,
+      :house_number,
+      :street_name,
+      :area,
+      :village,
+      :district,
+      :pincode,
+      :phone,
+      :alternate_phone,
+      :already_on_treatment,
+      :prior_heart_attack,
+      :heart_attack_in_last_3_years,
+      :prior_stroke,
+      :chronic_kidney_disease,
+      :diagnosed_with_hypertension,
+      :medication1_name,
+      :medication1_dose,
+      :medication2_name,
+      :medication2_dose,
+      :medication3_name,
+      :medication3_dose,
+      :medication4_name,
+      :medication4_dose
+    )
+  end
 
   def parse_boolean(value)
     case value.strip

--- a/app/models/concerns/sync_loggable.rb
+++ b/app/models/concerns/sync_loggable.rb
@@ -6,11 +6,12 @@ module SyncLoggable
   end
 
   def sync_status(sync_log)
-    return :unsynced unless sync_log.present?
+    return :unsynced if sync_log.blank?
+
     if sync_log.synced_at < updated_at
-      return :updated
+      :updated
     elsif sync_log.sync_errors.present?
-      return :sync_errored
+      :sync_errored
     else
       :synced
     end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -50,7 +50,7 @@ class Patient < ApplicationRecord
     patient_sync_status == :unsynced
   end
 
-  def sync_errors?
+  def sync_error?
     patient_sync_status == :sync_errored
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -50,6 +50,10 @@ class Patient < ApplicationRecord
     patient_sync_status == :unsynced
   end
 
+  def sync_errors?
+    patient_sync_status == :sync_errored
+  end
+
   def patient_sync_status
     sync_status(latest_patient_sync_log)
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -50,8 +50,12 @@ class Patient < ApplicationRecord
     patient_sync_status == :unsynced
   end
 
-  def sync_error?
-    patient_sync_status == :sync_errored
+  def syncable?
+    unsynced? || patient_sync_status == :updated
+  end
+
+  def editable?
+    unsynced? || patient_sync_status == :sync_errored
   end
 
   def patient_sync_status

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -6,7 +6,7 @@
 <h1><%= @facility.name %></h1>
 
 <%= link_to "Add Treatment Card", new_district_facility_patient_path(@district, @facility, @patient), class: "btn btn-primary" %>
-<% if policy(@facility).sync? && @facility.patients.map(&:unsynced?).any? %>
+<% if policy(@facility).sync? && @facility.patients.map(&:syncable?).any? %>
   <%= link_to "Sync Patients For Facility", district_facility_sync_path(@district, @facility), method: :post, class: "btn btn-warning float-right   mr-1" %>
 <% end %>
 

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -4,7 +4,7 @@
   <%= render "layouts/breadcrumbs/facility" %>
 </ul>
 
-<% if @patient.unsynced? %>
+<% if @patient.unsynced? || @patient.sync_errors? %>
   <%= link_to "Edit Patient", edit_district_facility_patient_path(@district, @facility, @patient), class: "btn btn-secondary float-right" %>
 <% end %>
 <% if policy(@patient).sync? && @patient.unsynced? %>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -4,7 +4,7 @@
   <%= render "layouts/breadcrumbs/facility" %>
 </ul>
 
-<% if @patient.unsynced? || @patient.sync_errors? %>
+<% if @patient.unsynced? || @patient.sync_error? %>
   <%= link_to "Edit Patient", edit_district_facility_patient_path(@district, @facility, @patient), class: "btn btn-secondary float-right" %>
 <% end %>
 <% if policy(@patient).sync? && @patient.unsynced? %>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -4,10 +4,10 @@
   <%= render "layouts/breadcrumbs/facility" %>
 </ul>
 
-<% if @patient.unsynced? || @patient.sync_error? %>
+<% if @patient.editable? %>
   <%= link_to "Edit Patient", edit_district_facility_patient_path(@district, @facility, @patient), class: "btn btn-secondary float-right" %>
 <% end %>
-<% if policy(@patient).sync? && @patient.unsynced? %>
+<% if policy(@patient).sync? && @patient.syncable? %>
   <%= link_to "Sync Patient", district_facility_patient_sync_path(@district, @facility, @patient), method: :post, class: "btn btn-warning float-right mr-1" %>
 <% end %>
 

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -30,6 +30,6 @@ FactoryBot.define do
     medication4_name ""
     medication4_dose ""
 
-    patient_uuid SecureRandom.uuid
+    patient_uuid { SecureRandom.uuid }
   end
 end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -29,5 +29,7 @@ FactoryBot.define do
     medication3_dose ""
     medication4_name ""
     medication4_dose ""
+
+    patient_uuid SecureRandom.uuid
   end
 end

--- a/spec/factories/sync_logs.rb
+++ b/spec/factories/sync_logs.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :sync_log do
+    simple_id { SecureRandom.uuid }
+    simple_model 'Patient'
+    synced_at { Time.now }
+
+    trait(:with_sync_errors) do
+      sync_errors do
+        { "error" => ["There was a sync error for the record"],
+          "id" => simple_id }
+      end
+    end
+  end
+end

--- a/spec/factories/sync_logs.rb
+++ b/spec/factories/sync_logs.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :sync_log do
-    simple_id { SecureRandom.uuid }
+    simple_id SecureRandom.uuid
     simple_model 'Patient'
     synced_at { Time.now }
 

--- a/spec/factories/sync_logs.rb
+++ b/spec/factories/sync_logs.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :sync_log do
-    simple_id SecureRandom.uuid
+    simple_id { SecureRandom.uuid }
     simple_model 'Patient'
     synced_at { Time.now }
 

--- a/spec/features/facilities_spec.rb
+++ b/spec/features/facilities_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Facilities", type: :feature do
       click_link facility.name
     end
 
-    context "treatments cards" do
+    context "treatment cards" do
       it "show all in the facility" do
         expect(page).to have_link(patient_1.formatted_treatment_number)
         expect(page).to have_link(patient_2.formatted_treatment_number)

--- a/spec/features/facilities_spec.rb
+++ b/spec/features/facilities_spec.rb
@@ -19,13 +19,40 @@ RSpec.feature "Facilities", type: :feature do
       click_link facility.name
     end
 
-    it "shows all treatment cards in the facility" do
-      expect(page).to have_link(patient_1.formatted_treatment_number)
-      expect(page).to have_link(patient_2.formatted_treatment_number)
+    context "treatments cards" do
+      it "show all in the facility" do
+        expect(page).to have_link(patient_1.formatted_treatment_number)
+        expect(page).to have_link(patient_2.formatted_treatment_number)
+      end
+
+      it "does not show any from another facility" do
+        expect(page).not_to have_link(other_patient.formatted_treatment_number)
+      end
     end
 
-    it "does not show treatment cards from another facility" do
-      expect(page).not_to have_link(other_patient.formatted_treatment_number)
+    context "facility sync" do
+      it "does not allow syncing patients for facility when all patients are already synced" do
+        create(:sync_log, simple_id: patient_1.patient_uuid)
+        create(:sync_log, simple_id: patient_2.patient_uuid)
+
+        visit current_path
+
+        expect(page).not_to have_link(href: district_facility_sync_path(district.id, facility.id))
+      end
+
+      it "allows syncing patients for facility if any patient was updated" do
+        patient_with_sync_errors = create(:patient, facility: facility)
+        create(:sync_log, :with_sync_errors, simple_id: patient_with_sync_errors.patient_uuid)
+
+        patient_with_sync_errors.update(updated_at: Time.now)
+        visit current_path
+
+        expect(page).to have_link(href: district_facility_sync_path(district.id, facility.id))
+      end
+
+      it "allows syncing patients for facility if any patient is not synced" do
+        expect(page).to have_link(href: district_facility_sync_path(district.id, facility.id))
+      end
     end
   end
 end

--- a/spec/features/patients_spec.rb
+++ b/spec/features/patients_spec.rb
@@ -10,11 +10,10 @@ RSpec.feature "Patients", type: :feature do
   let(:operator) { create(:user, :operator) }
 
   describe "show" do
-    context "as an operator" do
+    context "for an operator" do
       before do
         sign_in(operator)
         visit district_facility_path(district, facility)
-
         click_link patient.formatted_treatment_number
       end
 
@@ -30,7 +29,7 @@ RSpec.feature "Patients", type: :feature do
       end
     end
 
-    context "as an admin" do
+    context "for an admin" do
       before do
         sign_in(admin)
         visit district_facility_path(district, facility)

--- a/spec/features/patients_spec.rb
+++ b/spec/features/patients_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Patients", type: :feature do
 
           visit current_path
 
-          expect(page).to_not have_link(href: edit_district_facility_patient_path(district.id, facility.id, patient.id))
+          expect(page).not_to have_link(href: edit_district_facility_patient_path(district.id, facility.id, patient.id))
         end
       end
 
@@ -45,7 +45,7 @@ RSpec.feature "Patients", type: :feature do
           patient.update(updated_at: Time.now)
           visit current_path
 
-          expect(page).to_not have_link(href: district_facility_patient_sync_path(district.id, facility.id, patient.id))
+          expect(page).not_to have_link(href: district_facility_patient_sync_path(district.id, facility.id, patient.id))
         end
       end
     end
@@ -73,7 +73,7 @@ RSpec.feature "Patients", type: :feature do
 
           visit current_path
 
-          expect(page).to_not have_link(href: edit_district_facility_patient_path(district.id, facility.id, patient.id))
+          expect(page).not_to have_link(href: edit_district_facility_patient_path(district.id, facility.id, patient.id))
         end
       end
 
@@ -83,7 +83,7 @@ RSpec.feature "Patients", type: :feature do
 
           visit current_path
 
-          expect(page).to_not have_link(href: district_facility_patient_sync_path(district.id, facility.id, patient.id))
+          expect(page).not_to have_link(href: district_facility_patient_sync_path(district.id, facility.id, patient.id))
         end
 
         it "is allowed for a patient with an updated record" do
@@ -100,7 +100,7 @@ RSpec.feature "Patients", type: :feature do
 
           visit current_path
 
-          expect(page).to_not have_link(href: district_facility_patient_sync_path(district.id, facility.id, patient.id))
+          expect(page).not_to have_link(href: district_facility_patient_sync_path(district.id, facility.id, patient.id))
         end
       end
     end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -61,18 +61,48 @@ RSpec.describe Patient, type: :model do
     end
   end
 
-  describe "#sync_error?" do
+  describe "#syncable?" do
+    it "should return true if the patient has not been synced" do
+      patient_with_sync_errors = create(:patient)
+
+      expect(patient_with_sync_errors.syncable?).to be true
+    end
+
+    it "should return true if the patient's sync status has no errors" do
+      patient_with_no_sync_errors = create(:patient)
+
+      expect(patient_with_no_sync_errors.syncable?).to be true
+    end
+
+    it "should return false if the patient's sync status has errors" do
+      patient_with_sync_errors = create(:patient)
+      create(:sync_log, :with_sync_errors, simple_id: patient_with_sync_errors.patient_uuid)
+
+      expect(patient_with_sync_errors.syncable?).to be false
+    end
+
+    it "should return true if the patient's record has been updated" do
+      patient_with_sync_errors = create(:patient)
+      create(:sync_log, :with_sync_errors, simple_id: patient_with_sync_errors.patient_uuid)
+
+      patient_with_sync_errors.update(updated_at: Time.now)
+
+      expect(patient_with_sync_errors.syncable?).to be true
+    end
+  end
+
+  describe "#editable?" do
     it "should return true if the patient's sync status has errors" do
       patient_with_sync_errors = create(:patient)
       create(:sync_log, :with_sync_errors, simple_id: patient_with_sync_errors.patient_uuid)
 
-      expect(patient_with_sync_errors.sync_error?).to be true
+      expect(patient_with_sync_errors.editable?).to be true
     end
 
-    it "should return false if the patient's sync status has no errors" do
+    it "should return true if the patient has not been synced" do
       patient_with_no_sync_errors = create(:patient)
 
-      expect(patient_with_no_sync_errors.sync_error?).to be false
+      expect(patient_with_no_sync_errors.editable?).to be true
     end
   end
 end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -60,4 +60,19 @@ RSpec.describe Patient, type: :model do
       expect(patient.treatment_number_prefix).to eq("")
     end
   end
+
+  describe "#sync_error?" do
+    it "should return true if the patient's sync status has errors" do
+      patient_with_sync_errors = create(:patient)
+      create(:sync_log, :with_sync_errors, simple_id: patient_with_sync_errors.patient_uuid)
+
+      expect(patient_with_sync_errors.sync_error?).to be true
+    end
+
+    it "should return false if the patient's sync status has no errors" do
+      patient_with_no_sync_errors = create(:patient)
+
+      expect(patient_with_no_sync_errors.sync_error?).to be false
+    end
+  end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163649457

* Patients with sync errors should be editable
* Updated patients should be allowed to sync after the sync errors have been resolved