### PR TITLE
Disallow facility creation via Card Reader.

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -17,29 +17,7 @@ class FacilitiesController < ApplicationController
     @patient_sync_report = SyncReport.new(@patients.sync_statuses)
   end
 
-  def new
-    @facility = @district.facilities.build(author: current_user)
-    authorize @facility
-  end
-
   def edit
-  end
-
-  def create
-    @facility = @district.facilities.new(facility_params.merge(author: current_user))
-    authorize @facility
-
-    respond_to do |format|
-      if @facility.save
-        format.html { redirect_to district_path(@district), notice: 'Facility was successfully created.' }
-        format.json { render :show, status: :created, location: @facility }
-      else
-        @facilities = Facility.all
-
-        format.html { render :new }
-        format.json { render json: @facility.errors, status: :unprocessable_entity }
-      end
-    end
   end
 
   def update

--- a/app/views/districts/show.html.erb
+++ b/app/views/districts/show.html.erb
@@ -15,9 +15,3 @@
   <% end %>
   </tbody>
 </table>
-
-<section>
-  <h2>
-    <%= link_to "Facility not listed?", new_district_facility_path(@district), class: "btn btn-outline-dark" %>
-  </h2>
-</section>

--- a/app/views/facilities/new.html.erb
+++ b/app/views/facilities/new.html.erb
@@ -1,5 +1,0 @@
-<h1>New Facility</h1>
-
-<%= render 'form', facility: @facility %>
-
-<%= link_to 'Back', url_for(:back) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   resources :users
 
   resources :districts do
-    resources :facilities, except: [:new, :create] do
+    resources :facilities, only: [:index, :show, :edit, :update, :destroy] do
       post :sync
       resources :patients do
         post :sync

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   resources :users
 
   resources :districts do
-    resources :facilities do
+    resources :facilities, except: [:new, :create] do
       post :sync
       resources :patients do
         post :sync

--- a/spec/features/districts_spec.rb
+++ b/spec/features/districts_spec.rb
@@ -39,9 +39,5 @@ RSpec.feature "Districts", type: :feature do
     it "does not show facilities from other districts" do
       expect(page).not_to have_link(bathinda_chc.name)
     end
-
-    it 'should have a link to create new facilities' do
-      expect(page).to have_link(href: new_district_facility_path(mansa))
-    end
   end
 end

--- a/spec/features/facilities_spec.rb
+++ b/spec/features/facilities_spec.rb
@@ -57,28 +57,4 @@ RSpec.feature "Facilities", type: :feature do
       end
     end
   end
-
-  describe "new" do
-    describe "adding a facility" do
-      before do
-        visit new_district_facility_path(district)
-      end
-
-      it "displays the new facility" do
-        fill_in "Facility name", with: "PHC Paldi"
-        click_button "Add"
-
-        expect(page).to have_link("PHC Paldi")
-
-        new_facility = Facility.find_by(name: "PHC Paldi")
-        expect(new_facility.district).to eq(district)
-        expect(new_facility.author).to eq(admin)
-      end
-
-      it "shows the correct error if name is blank" do
-        click_button "Add"
-        expect(page).to have_content("Facility name can't be blank")
-      end
-    end
-  end
 end


### PR DESCRIPTION
PR for story: [Disallow creating facilities from card-reader since there is no mechanism to sync the facility with Simple that causes sync failures](https://www.pivotaltracker.com/n/projects/2184102/stories/163936174)

 * Removed option to create new facility from the districts view.
 * Removed routes for facility creation from routes.