### PR TITLE
Sync patients with age as zero when it is missing

### DIFF
--- a/app/payloads/sync_patient_payload.rb
+++ b/app/payloads/sync_patient_payload.rb
@@ -15,7 +15,7 @@ class SyncPatientPayload
       full_name: patient.name.split(' ').map(&:humanize).join(' '),
       status: 'active',
       date_of_birth: nil,
-      age: patient.age,
+      age: patient.age || 0,
       age_updated_at: now,
       created_at: patient.registered_on_without_timestamp,
       updated_at: patient.registered_on_without_timestamp,


### PR DESCRIPTION
When a patient is missing an age, currently when we attempt to sync them, they fail due to api validations on simple server. This PR marks the age as 0 when it is missing these patients can be synced with the server. 